### PR TITLE
ci: Fix GH pages deploy workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,3 +1,4 @@
+# https://docs.astro.build/en/guides/deploy/github/#configure-a-github-action
 name: Deploy to GitHub Pages
 
 on:
@@ -6,7 +7,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: gh-pages
+  group: github-pages
   cancel-in-progress: false
 
 # Allow this job to clone the repo and create a page deployment
@@ -23,11 +24,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup
-        uses: ./.github/actions/setup
-
-      - name: Run build
-        run: pnpm build
+      - name: Install dependencies, run build and upload as artifact
+        uses: withastro/action@v3
 
   deploy:
     name: Deploy


### PR DESCRIPTION
I thought I'd do the steps manually myself, so the deployment can benefit from the cache that is used from the composite action. However, I now don't think it is worth it to maintain the manual steps, just to save a couple seconds.