### PR TITLE
feat: Implement basic navbar and mode switcher

### DIFF
--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -33,9 +33,7 @@ const routes = [
 <script>
   const button = document.querySelector('button.theme-toggle');
 
-  if (!button) return;
-
-  button.addEventListener('click', () => {
+  button?.addEventListener('click', () => {
     const theme =
       document.documentElement.getAttribute('data-color-scheme') ?? 'light';
 

--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -1,0 +1,50 @@
+---
+const baseUrl = import.meta.env.BASE_URL;
+const pathname = Astro.url.pathname;
+
+const routes = [
+  {
+    href: baseUrl,
+    name: 'Home',
+  },
+  {
+    href: `${baseUrl}/companies`,
+    name: 'Projects',
+  },
+].map((route) => ({
+  ...route,
+  isActive: [route.href, `${route.href}/`].includes(pathname),
+}));
+---
+
+<nav>
+  <menu>
+    {
+      routes.map((route) => (
+        <li class:list={[{ selected: route.isActive }]}>
+          <a href={route.href}>{route.name}</a>
+        </li>
+      ))
+    }
+    <button class="theme-toggle">Toggle Theme</button>
+  </menu>
+</nav>
+
+<script>
+  const button = document.querySelector('button.theme-toggle');
+
+  if (!button) return;
+
+  button.addEventListener('click', () => {
+    const theme =
+      document.documentElement.getAttribute('data-color-scheme') ?? 'light';
+
+    if (theme === 'light') {
+      document.documentElement.setAttribute('data-color-scheme', 'dark');
+      localStorage.setItem('theme', 'dark');
+    } else {
+      document.documentElement.setAttribute('data-color-scheme', 'light');
+      localStorage.setItem('theme', 'light');
+    }
+  });
+</script>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -14,6 +14,7 @@ const baseUrl = import.meta.env.BASE_URL;
     <meta name="viewport" content="width=device-width" />
     <link rel="icon" type="image/svg+xml" href={`${baseUrl}/favicon.svg`} />
     <meta name="generator" content={Astro.generator} />
+    <link rel="stylesheet" href="https://matcha.mizu.sh/matcha.css" />
     <title>{title}</title>
   </head>
   <body>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,4 +1,6 @@
 ---
+import Navbar from '../components/Navbar.astro';
+
 interface Props {
   title?: string;
 }
@@ -16,23 +18,34 @@ const baseUrl = import.meta.env.BASE_URL;
     <meta name="generator" content={Astro.generator} />
     <link rel="stylesheet" href="https://matcha.mizu.sh/matcha.css" />
     <title>{title}</title>
+
+    <script is:inline>
+      const localStorageTheme = localStorage.getItem('theme');
+
+      if (localStorageTheme === null) {
+        if (!window.matchMedia) {
+          document.documentElement.setAttribute('data-color-scheme', 'light');
+        } else {
+          const darkQuery = window.matchMedia('(prefers-color-scheme: dark)');
+
+          if (darkQuery.matches) {
+            document.documentElement.setAttribute('data-color-scheme', 'dark');
+          } else {
+            document.documentElement.setAttribute('data-color-scheme', 'light');
+          }
+        }
+      } else {
+        document.documentElement.setAttribute(
+          'data-color-scheme',
+          localStorageTheme,
+        );
+      }
+    </script>
   </head>
   <body>
-    <nav>
-      <a href={baseUrl}>Home</a>
-      <a href={`${baseUrl}/companies`}>Projects</a>
-    </nav>
+    <Navbar />
     <main>
       <slot />
     </main>
   </body>
 </html>
-
-<style>
-  html,
-  body {
-    margin: 0;
-    width: 100%;
-    height: 100%;
-  }
-</style>


### PR DESCRIPTION
- Basic `Navbar` component allows to navigate the page
- Added drop-in css library for basic styling: https://matcha.mizu.sh
- Light/dark mode is automatically detected and set based on browser/system preference
  - A light/dark mode switcher allows to toggle the mode manually, to overwrite the system preference.